### PR TITLE
Updated href for contact button

### DIFF
--- a/packages/site/src/components/Custom/ButtonWithIcon.tsx
+++ b/packages/site/src/components/Custom/ButtonWithIcon.tsx
@@ -8,7 +8,7 @@ export enum iconPositions {
 }
 
 export interface ButtonWithIconProps {
-  icon: any;
+  icon?: any;
   iconPosition: iconPositions;
   link: LinkProps;
   hasExternalIcon: boolean;

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -155,7 +155,6 @@ function ArticlePageAndNavigationInternal({
         </div>
 
         <ButtonWithIcon
-          icon={<EnvelopeIcon className="mx-1 w-4" />}
           iconPosition={iconPositions.before}
           link={{
             href: 'https://qutvirtual4.qut.edu.au/group/research-students/conducting-research/specialty-research-facilities/advanced-research-computing-storage',

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -158,7 +158,7 @@ function ArticlePageAndNavigationInternal({
           icon={<EnvelopeIcon className="mx-1 w-4" />}
           iconPosition={iconPositions.before}
           link={{
-            href: 'mailto:eresearch@qut.edu.au',
+            href: 'https://qutvirtual4.qut.edu.au/group/research-students/conducting-research/specialty-research-facilities/advanced-research-computing-storage',
             text: 'Contact eResearch',
             isExternal: true,
           }}


### PR DESCRIPTION
Contact eResearch button
![image](https://github.com/user-attachments/assets/a0782462-519b-456e-893a-97dae53f68c8) 
now goes to:
https://qutvirtual4.qut.edu.au/group/research-students/conducting-research/specialty-research-facilities/advanced-research-computing-storage